### PR TITLE
Backport to .NET5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x.x
+          dotnet-version: 5.x.x
         
       - run: dotnet test AssimpNet.Test -c ${{ matrix.configuration }} ${{ matrix.additional_args }}
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 5.x.x
+          dotnet-version: 6.x.x
         
       - run: dotnet test AssimpNet.Test -c ${{ matrix.configuration }} ${{ matrix.additional_args }}
           

--- a/AssimpNet.Sample/AssimpNet.Sample.csproj
+++ b/AssimpNet.Sample/AssimpNet.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Assimp.Sample</RootNamespace>
     <ApplicationIcon />
     <StartupObject />

--- a/AssimpNet.Test/AssimpContextTestFixture.cs
+++ b/AssimpNet.Test/AssimpContextTestFixture.cs
@@ -385,12 +385,12 @@ namespace Assimp.Test
         {
             LogStream.IsVerboseLoggingEnabled = true;
 
-            ThreadStart[] actions =
-            [
+            ThreadStart[] actions = new ThreadStart[]
+            {
                 LoadSceneA,
                 LoadSceneB,
                 ConvertSceneC,
-            ];
+            };
 
             var threads = Enumerable.Repeat(actions, 25)
                 .SelectMany(x => x)

--- a/AssimpNet.Test/AssimpNet.Test.csproj
+++ b/AssimpNet.Test/AssimpNet.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>Assimp.Test</RootNamespace>
     <LangVersion>latest</LangVersion>
     <ForceCopyNativeAssimp>true</ForceCopyNativeAssimp>

--- a/AssimpNet/AssimpNet.csproj
+++ b/AssimpNet/AssimpNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/AssimpNet/ImporterDescription.cs
+++ b/AssimpNet/ImporterDescription.cs
@@ -95,7 +95,7 @@ namespace Assimp
             string fileExts = Marshal.PtrToStringAnsi(descr.FileExtensions);
             if(string.IsNullOrEmpty(fileExts))
             {
-                m_fileExtensions = [];
+                m_fileExtensions = Array.Empty<string>();
             }
             else
             {

--- a/AssimpNet/Material.cs
+++ b/AssimpNet/Material.cs
@@ -1358,7 +1358,7 @@ namespace Assimp
             int count = GetMaterialTextureCount(type);
 
             if(count == 0)
-                return [];
+                return Array.Empty<TextureSlot>();
 
             TextureSlot[] textures = new TextureSlot[count];
 

--- a/AssimpNet/Matrix3x3.cs
+++ b/AssimpNet/Matrix3x3.cs
@@ -495,6 +495,7 @@ namespace Assimp
                                 1 => v.X,
                                 2 => v.Y,
                                 3 => v.Z,
+                                _ => 0,
                             };
                         }
                     }

--- a/AssimpNet/Matrix3x3.cs
+++ b/AssimpNet/Matrix3x3.cs
@@ -484,7 +484,19 @@ namespace Assimp
                 {
                     for(int j = 1; j < 4; j++)
                     {
-                        m[i, j] = -c1 * u[i] * u[j] - c2 * v[i] * v[j] + c3 * v[i] * u[j];
+                        m[i, j] = -c1 * Index(u, i) * Index(u, j) - c2 * Index(v, i) * Index(v, j) + c3 * Index(v, i) * Index(u, j);
+
+                        continue;
+
+                        static float Index(Vector3 v, int i)
+                        {
+                            return i switch
+                            {
+                                1 => v.X,
+                                2 => v.Y,
+                                3 => v.Z,
+                            };
+                        }
                     }
                     m[i, i] += 1.0f;
                 }

--- a/AssimpNet/MemoryHelper.cs
+++ b/AssimpNet/MemoryHelper.cs
@@ -135,7 +135,7 @@ namespace Assimp
             where Native : struct
         {
             if(nativeArray == IntPtr.Zero || length == 0)
-                return [];
+                return Array.Empty<Managed>();
 
             //If the pointer is a void** we need to step by the pointer size, otherwise it's just a void* and step by the type size.
             int stride = (arrayOfPointers) ? IntPtr.Size : MarshalSizeOf<Native>();

--- a/AssimpNet/Unmanaged/AssimpLibrary.cs
+++ b/AssimpNet/Unmanaged/AssimpLibrary.cs
@@ -183,7 +183,7 @@ namespace Assimp.Unmanaged
             int count = (int) GetFunction<Functions.aiGetExportFormatCount>(FunctionNames.aiGetExportFormatCount)().ToUInt32();
 
             if(count == 0)
-                return [];
+                return Array.Empty<ExportFormatDescription>();
 
             ExportFormatDescription[] descriptions = new ExportFormatDescription[count];
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The library is split between two parts, a low level and a high level. The intent
 
 ## Supported Frameworks ##
 
-The library runs on **.NET 7**.
+The library runs on **.NET 5**.
 
 ## Supported Platforms ##
 


### PR DESCRIPTION
The decision to simply bump the version to .NET7 was purely out of convenience because it provided a tiny little utility function that the Matrix3x3 implementation uses. This decision was made when this wasn't really intended to be a proper continuation of the project but simply a quick and dirty fork that would work for my purposes. I realize that considering the broader userbase people might genuinely benefit from this.

Theoretically it should be possible to support netstandard and netcoreapp versions, however, I do not think that the benefits outweigh the costs at this time. If you are someone that would benefit from this feel free to raise an issue and I will see what can be done.